### PR TITLE
README: Add Markdown code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gutenberg, dammit
 
-By [Allison Parrish](http://www.decontextualize.com/)
+By [Allison Parrish](https://www.decontextualize.com/)
 
 *Gutenberg, dammit* is a corpus of every plaintext file in Project Gutenberg (up
 until June 2016), organized in a consistent fashion, with (mostly?) consistent
@@ -14,7 +14,7 @@ The name of the corpus was inspired by Leonard Richardson's [Unicode,
 dammit](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#unicode-dammit).
 
 Code in this repository relies on the data prepared by the [GutenTag
-project](http://www.cs.toronto.edu/~jbrooke/gutentag/) (Brooke 2015) and the
+project](https://www.cs.toronto.edu/~jbrooke/gutentag/) (Brooke 2015) and the
 code is partially based on the [GutenTag source
 code](https://github.com/julianbrooke/GutenTag).
 
@@ -59,7 +59,7 @@ To search for and retrieve files whose metadata contains particular strings:
 >>> from gutenbergdammit.ziputils import searchandretrieve
 >>> for info, text in searchandretrieve("gutenberg-dammit-files-v002.zip", {'Title': 'Made Easy'}):
 ...     print(info['Title'][0], len(text))
-... 
+...
 Entertaining Made Easy 108314
 Reading Made Easy for Foreigners - Third Reader 209964
 The Art of Cookery Made Easy and Refined 262990
@@ -134,7 +134,7 @@ The lower-case fields are metadata specific to this corpus, explained below:
 #### What was included, what was left out
 
 First off, *Gutenberg, dammit* is based on files from [Project
-Gutenberg](http://www.gutenberg.org/), and doesn't include files from any of
+Gutenberg](https://www.gutenberg.org/), and doesn't include files from any of
 the related international projects (e.g. Project Gutenberg Canada, Project
 Gutenberg Australia).
 
@@ -172,9 +172,10 @@ follows. If you want to be able to recreate the process of how I made the
 corpus, read on.
 
 The scripts in this repository work on the files prepared by
-[GutenTag](http://www.cs.toronto.edu/~jbrooke/gutentag/download.html). In order
-to use the scripts, you'll need to download their corpus ("Our (full) Project
-Gutenberg Corpus", ~7 GB ZIP file) and unzip it into a directory on your system.
+[GutenTag](https://www.cs.toronto.edu/~jbrooke/gutentag/download.html). In
+order to use the scripts, you'll need to download their corpus ("Our (full)
+Project Gutenberg Corpus", ~7 GB ZIP file) and unzip it into a directory on
+your system.
 
 The included package `gutenbergdammit/build.py` is designed to be used as a
 command-line script. Run it on the command line like so:
@@ -232,7 +233,7 @@ welcome.
   GutenTag corpus, which is a combination of the 2010 DVD ISO and I think more
   recent entries collected via web scraping?)
 * Implement a process for adding newer files to the corpus (by looking at the
-  [RSS feed](http://www.gutenberg.org/wiki/Gutenberg:Feeds)?)
+  [RSS feed](https://www.gutenberg.org/wiki/Gutenberg:Feeds)?)
 * Make the corpus zip file into a torrent or something so I'm not paying for
   every download
 
@@ -240,7 +241,7 @@ welcome.
 
 Brooke, Julian, et al. “[GutenTag: An NLP-Driven Tool for Digital Humanities
 Research in the Project Gutenberg
-Corpus](http://www.cs.toronto.edu/pub/gh/Brooke-etal-2015-CLfL.pdf).” CLfL@
+Corpus](https://www.cs.toronto.edu/pub/gh/Brooke-etal-2015-CLfL.pdf).” CLfL@
 NAACL-HLT, 2015, pp. 42–47.
 
 ## Version history
@@ -255,6 +256,6 @@ In accordance with GutenTag's license:
 
 This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
 International License. To view a copy of this license, visit
-http://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative
+https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to Creative
 Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
 

--- a/README.md
+++ b/README.md
@@ -37,30 +37,36 @@ or use them directly by installing this package from the repo:
 First, download the ZIP archive and put it in the same directory as your Python
 code. Then, to (e.g.) retrieve the text of one particular file from the corpus:
 
-    >>> from gutenbergdammit.ziputils import retrieve_one
-    >>> text = retrieve_one("gutenberg-dammit-files-v002.zip", "123/12345.txt")
-    >>> text[:50]
-    '[Illustration: "I saw there something missing from'
+```python
+>>> from gutenbergdammit.ziputils import retrieve_one
+>>> text = retrieve_one("gutenberg-dammit-files-v002.zip", "123/12345.txt")
+>>> text[:50]
+'[Illustration: "I saw there something missing from'
+```
 
 To retrieve the metadata file:
 
-    >>> from gutenbergdammit.ziputils import loadmetadata
-    >>> metadata = loadmetadata("gutenberg-dammit-files-v002.zip")
-    >>> metadata[456]['Title']
-    ['Essays in the Art of Writing']
+```python
+>>> from gutenbergdammit.ziputils import loadmetadata
+>>> metadata = loadmetadata("gutenberg-dammit-files-v002.zip")
+>>> metadata[456]['Title']
+['Essays in the Art of Writing']
+```
 
 To search for and retrieve files whose metadata contains particular strings:
 
-    >>> from gutenbergdammit.ziputils import searchandretrieve
-    >>> for info, text in searchandretrieve("gutenberg-dammit-files-v002.zip", {'Title': 'Made Easy'}):
-    ...     print(info['Title'][0], len(text))
-    ... 
-    Entertaining Made Easy 108314
-    Reading Made Easy for Foreigners - Third Reader 209964
-    The Art of Cookery Made Easy and Refined 262990
-    Shaving Made Easy	What the Man Who Shaves Ought to Know 44982
-    Writing and Drawing Made Easy, Amusing and Instructive	Containing The Whole Alphabet in all the Characters now	us'd, Both in Printing and Penmanship 10036
-    Etiquette Made Easy 119770
+```python
+>>> from gutenbergdammit.ziputils import searchandretrieve
+>>> for info, text in searchandretrieve("gutenberg-dammit-files-v002.zip", {'Title': 'Made Easy'}):
+...     print(info['Title'][0], len(text))
+... 
+Entertaining Made Easy 108314
+Reading Made Easy for Foreigners - Third Reader 209964
+The Art of Cookery Made Easy and Refined 262990
+Shaving Made Easy	What the Man Who Shaves Ought to Know 44982
+Writing and Drawing Made Easy, Amusing and Instructive	Containing The Whole Alphabet in all the Characters now	us'd, Both in Printing and Penmanship 10036
+Etiquette Made Easy 119770
+```
 
 ### Details
 
@@ -85,23 +91,25 @@ should have.
 The `gutenberg-metadata.json` file in the zip is a big JSON file with metadata on
 each book. The is a list of JSON objects with the following format:
 
-    {
-        "Author": [ "Robert Carlton Brown" ],
-        "Author Birth": [ 1886 ],
-        "Author Death": [ 1959 ],
-        "Author Given": [ "Robert Carlton" ],
-        "Author Surname": [ "Brown" ],
-        "Copyright Status": [ "Not copyrighted in the United States." ],
-        "Language": [ "English" ],
-        "LoC Class": [ "SF: Agriculture: Animal culture" ],
-        "Num": "14293",
-        "Subject": [ "Cookery (Cheese)", "Cheese" ],
-        "Title": [ "The Complete Book of Cheese" ],
-        "charset": "iso-8859-1",
-        "gd-num-padded": "14293",
-        "gd-path": "142/14293.txt",
-        "href": "/1/4/2/9/14293/14293_8.zip"
-    }
+```json
+{
+    "Author": [ "Robert Carlton Brown" ],
+    "Author Birth": [ 1886 ],
+    "Author Death": [ 1959 ],
+    "Author Given": [ "Robert Carlton" ],
+    "Author Surname": [ "Brown" ],
+    "Copyright Status": [ "Not copyrighted in the United States." ],
+    "Language": [ "English" ],
+    "LoC Class": [ "SF: Agriculture: Animal culture" ],
+    "Num": "14293",
+    "Subject": [ "Cookery (Cheese)", "Cheese" ],
+    "Title": [ "The Complete Book of Cheese" ],
+    "charset": "iso-8859-1",
+    "gd-num-padded": "14293",
+    "gd-path": "142/14293.txt",
+    "href": "/1/4/2/9/14293/14293_8.zip"
+}
+```
 
 The capitalized fields correspond to the fields in the official Project
 Gutenberg metadata, with information about the author broken out into the
@@ -171,8 +179,10 @@ Gutenberg Corpus", ~7Gb ZIP file) and unzip it into a directory on your system.
 The included package `gutenbergdammit/build.py` is designed to be used as a
 command-line script. Run it on the command line like so:
 
-    python -m gutenbergdammit.build --src-path=<path to your gutentag download> \
-        --dest-path=output --metadata-file=output/gutenberg-metadata.json \
+```bash
+python -m gutenbergdammit.build --src-path=<path to your gutentag download> \
+    --dest-path=output --metadata-file=output/gutenberg-metadata.json \
+```
 
 Help on the options:
 
@@ -201,7 +211,9 @@ some of the files in the Gutenberg archive ("implosion"). Whoops. Included in
 the repository is a script that unzips and re-zips these files using a modern
 compression algorithm. To run it:
 
-    python -m gutenbergdammit.findbadzips --src-path=<gutentag_dump> --fix
+```bash
+python -m gutenbergdammit.findbadzips --src-path=<gutentag_dump> --fix
+```
 
 This will modify the ~100 files in your GutenTag dump with broken ZIP
 compression, and save copies of the originals (with `-orig` at the end of the

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ to accommodate books that (e.g.) have more than one author or title.
 The lower-case fields are metadata specific to this corpus, explained below:
 
 * `charset`: The character set of the original file. All of the files in the
-  ZIP are in UTF8 encoding, so this is only helpful if (e.g.) you're using the
+  ZIP are in UTF-8 encoding, so this is only helpful if (e.g.) you're using the
   metadata to refer back to the original file on the Gutenberg website.
 * `gd-num-padded`: The book number ("Gutenberg ID") left-padded to five digits
   with zeros.
@@ -156,7 +156,7 @@ doesn't mean you always have a right to use its words.
 
 #### Character encodings
 
-The included text files are all encoded as UTF8. When decoding from Project
+The included text files are all encoded as UTF-8. When decoding from Project
 Gutenberg, decoding is first attempted using the encoding declared in the
 file's metadata; if that decoding doesn't work, [`chardet`'s `detect`
 function](https://chardet.readthedocs.io/en/latest/usage.html#basic-usage) is
@@ -174,7 +174,7 @@ corpus, read on.
 The scripts in this repository work on the files prepared by
 [GutenTag](http://www.cs.toronto.edu/~jbrooke/gutentag/download.html). In order
 to use the scripts, you'll need to download their corpus ("Our (full) Project
-Gutenberg Corpus", ~7Gb ZIP file) and unzip it into a directory on your system.
+Gutenberg Corpus", ~7 GB ZIP file) and unzip it into a directory on your system.
 
 The included package `gutenbergdammit/build.py` is designed to be used as a
 command-line script. Run it on the command line like so:


### PR DESCRIPTION
For example:

![image](https://user-images.githubusercontent.com/1324225/44003676-5943b25a-9e5f-11e8-9d73-1f2d2ca9f306.png)

https://github.com/hugovk/gutenberg-dammit/blob/c8edc1e03ebf8675d585e21bf599a1e15e1e06c6/README.md

Also fix a couple of typos and use HTTPS in links where available.