### PR TITLE
Fix UnicodeDecodeError when installing on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
     
-with open('README.md') as readme_file:
+with open('README.md', encoding='UTF-8') as readme_file:
     readme = readme_file.read()
 
 setup(


### PR DESCRIPTION
Fixes #8.

* Passing Windows build: https://ci.appveyor.com/project/hugovk/gutenberg-dammit/builds/23655391
* Passing Linux build: https://travis-ci.org/hugovk/gutenberg-dammit/builds/516780575